### PR TITLE
fix: create/excel

### DIFF
--- a/src/Controllers/AssociatesController.cs
+++ b/src/Controllers/AssociatesController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 using src.Models;
 using src.Services;
 using src.Utils;
@@ -27,7 +28,7 @@ namespace src.Controllers
             {
                 var list = await _associateService.GetAll(pageNumber, pageSize, searchTerm, orderBy).ConfigureAwait(false);
 
-                if(list == null)
+                if (list == null)
                     return NoContent();
 
                 var total = await _associateService.GetCount(searchTerm).ConfigureAwait(false);
@@ -86,6 +87,28 @@ namespace src.Controllers
 
                 if (associateByIDCard != null)
                     return BadRequest(new { success = false, status = 400, message = "ID Card already exists" });
+
+                var response = await _associateService.Create(associate).ConfigureAwait(false);
+
+                return response != null ? CreatedAtAction(nameof(GetAssociateById), new { id = response.Id }, response) : StatusCode(StatusCodes.Status500InternalServerError, "Failed to create associate");
+
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+            }
+        }
+
+        [HttpPost("excel")]
+        public async Task<ActionResult<Associate>> CreateExcelAssociate([FromBody] Associate associate)
+        {
+            try
+            {
+                if (associate == null)
+                    return BadRequest(new { success = false, status = 400, message = "Invalid associate" });
+
+                if (!ModelState.IsValid)
+                    return BadRequest(new { success = false, status = 400, message = "Invalid associate" });
 
                 var response = await _associateService.Create(associate).ConfigureAwait(false);
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using src;
@@ -43,8 +44,6 @@ builder.Services.AddScoped<IAssociateService, AssociateService>();
 builder.Services.AddScoped<IAssociateRepository, AssociateRepository>();
 builder.Services.AddScoped<IAttendanceService, AttendanceService>();
 builder.Services.AddScoped<IAttendanceRepository, AttendanceRepository>();
-
-
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle


### PR DESCRIPTION
El mismo create solo que son validaciones de correo o cédula.

[HttpPost("excel")]
public async Task<ActionResult<Associate>> CreateExcelAssociate([FromBody] Associate associate)
{
    try
    {
        if (associate == null)
            return BadRequest(new { success = false, status = 400, message = "Invalid associate" });

        if (!ModelState.IsValid)
            return BadRequest(new { success = false, status = 400, message = "Invalid associate" });

        var response = await _associateService.Create(associate).ConfigureAwait(false);

        return response != null ? CreatedAtAction(nameof(GetAssociateById), new { id = response.Id }, response) : StatusCode(StatusCodes.Status500InternalServerError, "Failed to create associate");

    }
    catch (Exception ex)
    {
        return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
    }
}